### PR TITLE
feat: add `wallet.GenerateWallet` function corresponding to `arweave.wallets.generate()`

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -50,6 +50,7 @@ func GenerateWallet() *Wallet {
 
 	// Finally base64url encode it to have the resulting address
 	w.address = utils.EncodeToBase64(h.Sum(nil))
+	w.publicKey = utils.EncodeToBase64(rsaKey.N.Bytes())
 	return w
 }
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -31,6 +31,12 @@ func NewWallet() *Wallet {
 	return &Wallet{}
 }
 
+// GenerateWallet generates a new JWK wallet.
+func GenerateWallet() *Wallet {
+	reader := rand.Reader
+	key, _ := rsa.GenerateKey(reader, 4096)
+}
+
 // Address returns the address of the account
 func (w *Wallet) Address() string {
 	return w.address

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -34,7 +34,23 @@ func NewWallet() *Wallet {
 // GenerateWallet generates a new JWK wallet.
 func GenerateWallet() *Wallet {
 	reader := rand.Reader
-	key, _ := rsa.GenerateKey(reader, 4096)
+	rsaKey, _ := rsa.GenerateKey(reader, 4096)
+	w := &Wallet{}
+
+	w.key = &gojwk.Key{
+		Kty: "RSA",
+		N: utils.EncodeToBase64(rsaKey.N.Bytes()),
+		E: utils.EncodeToBase64(big.NewInt(int64(rsaKey.E)).Bytes()),
+		D: utils.EncodeToBase64(rsaKey.D.Bytes()),
+	}
+	w.pubKey = rsaKey.Public().(*rsa.PublicKey)
+	// Take the "n", in bytes and hash it using SHA256
+	h := sha256.New()
+	h.Write(rsaKey.N.Bytes())
+
+	// Finally base64url encode it to have the resulting address
+	w.address = utils.EncodeToBase64(h.Sum(nil))
+	return w
 }
 
 // Address returns the address of the account

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -57,3 +57,20 @@ func TestSignature(t *testing.T) {
 	}
 
 }
+
+func TestGeneration(t *testing.T) {
+	w := GenerateWallet()
+
+	toSign := []byte("hello")
+	msg := sha256.Sum256(toSign)
+
+	sig, err := w.Sign(msg[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.Verify(msg[:], sig)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adds `GenerateWallet` function to the `wallet` package.

- [x] Creates an rsa private key (keylength=4096)
- [x] Use logic from `LoadKey` to generate a Wallet struct.
- [x] Added unit tests in `wallet_test.go`

Usage:
```go
w := wallet.GenerateWallet()
// ...
```

Prior art: `arweave.wallets.generate()` in `arweave-js`
```javascript
import Arweave from "arweave";
let client = Arweave.init(...);
let jwk = client.wallets.generate();
// ...
```

Related issues: #8 